### PR TITLE
implement setup_connection for H2Connection (no TLS)

### DIFF
--- a/examples/test-h2c.py
+++ b/examples/test-h2c.py
@@ -59,4 +59,12 @@ h2_conn.send_frames(temp_data_bytes)
 resp = h2_conn.read_response_from_socket(_timeout=10)
 frame_parser = h2_frames.FrameParser(h2_connection=h2_conn)
 frame_parser.add_frames(resp)
-frame_parser.show_response_of_sent_requests()
+
+h2_conn.close_connection()
+
+for x in frame_parser.headers_and_data_frames.keys():
+    sid = str(x)
+    d = frame_parser.headers_and_data_frames[x]
+    print(f'Stream ID: {sid}, response nano seconds: {d["nano_seconds"]}')
+    print(f'Headers: {str(d["header"])}')
+    print(f'Body (DATA): {str(d["data"])}')

--- a/examples/test-h2c.py
+++ b/examples/test-h2c.py
@@ -1,0 +1,62 @@
+from h2spacex import H2Connection
+from time import sleep
+from h2spacex import h2_frames
+
+h2_conn = H2Connection(
+    hostname='nghttp2.org',
+    port_number=80
+)
+
+headers = """accept: */*
+content-type: application/x-www-form-urlencoded
+...
+"""
+
+stream_ids_list = h2_conn.generate_stream_ids(number_of_streams=5)
+
+all_headers_frames = []  # all headers frame + data frames which have not the last byte
+all_data_frames = []  # all data frames which contain the last byte
+
+for s_id in stream_ids_list:
+    header_frames_without_last_byte, last_data_frame_with_last_byte = h2_conn.create_single_packet_http2_get_request_frames(
+        method='GET',
+        headers_string=headers,
+        scheme='http',
+        stream_id=s_id,
+        authority="nghttp2.org",
+        path="/"
+    )
+
+    all_headers_frames.append(header_frames_without_last_byte)
+    all_data_frames.append(last_data_frame_with_last_byte)
+
+# concatenate all headers bytes
+temp_headers_bytes = b''
+for h in all_headers_frames:
+    temp_headers_bytes += bytes(h)
+
+# concatenate all data frames which have last byte
+temp_data_bytes = b''
+for d in all_data_frames:
+    temp_data_bytes += bytes(d)
+
+h2_conn.setup_connection()
+h2_conn.send_ping_frame()  # important line (in improved version of single packet attack)
+
+# send header frames
+h2_conn.send_frames(temp_headers_bytes)
+
+# wait some time
+sleep(0.1)
+
+# send ping frame to warm up connection
+h2_conn.send_ping_frame()
+
+# send remaining data frames
+h2_conn.send_frames(temp_data_bytes)
+
+# print response of sent requests
+resp = h2_conn.read_response_from_socket(_timeout=10)
+frame_parser = h2_frames.FrameParser(h2_connection=h2_conn)
+frame_parser.add_frames(resp)
+frame_parser.show_response_of_sent_requests()

--- a/src/h2spacex/h2_connection.py
+++ b/src/h2spacex/h2_connection.py
@@ -58,10 +58,17 @@ class H2Connection:
         }
 
     def setup_connection(self):
-        """
-        TODO
-        :return:
-        """
+        try:
+            self._create_raw_socket()
+            self._send_h2_connection_preface()  # send HTTP/2 Connection Preface
+            self._send_client_initial_settings_frame()  # send client initial settings frame to server
+        except Exception as e:
+            t = '# Error in setting the connection up : ' + str(e)
+            logger.logger_print(t)
+            raise e
+
+        else:
+            self.is_connection_closed = False
 
     def __thread_response_frame_parsing(self, _timeout=0.5, print_responses=False):
         """


### PR DESCRIPTION
H2Connection's `setup_connection` was not implemented. I simply copied the code for H2OnTlsConnection and removed the line creating the TLS context.